### PR TITLE
Corrige a utilizacao do HttpClient

### DIFF
--- a/api30.sdk/pom.xml
+++ b/api30.sdk/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>br.cielo.cieloecommerce</groupId>
   <artifactId>api30.sdk</artifactId>
-  <version>0.0.4-SNAPSHOT</version>
+  <version>0.0.5-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>api30.sdk</name>

--- a/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/CieloEcommerce.java
+++ b/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/CieloEcommerce.java
@@ -2,7 +2,7 @@
 
 import cieloecommerce.sdk.Merchant;
 import cieloecommerce.sdk.ecommerce.request.*;
-import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
 
 import java.io.IOException;
 
@@ -12,7 +12,7 @@ import java.io.IOException;
 public class CieloEcommerce {
 	private final Merchant merchant;
 	private final Environment environment;
-	private HttpClient httpClient;
+	private CloseableHttpClient httpClient;
 
 	/**
 	 * Create an instance of CieloEcommerce choosing the environment where the
@@ -39,7 +39,7 @@ public class CieloEcommerce {
 		this(merchant, Environment.PRODUCTION);
 	}
 
-	public void setHttpClient(HttpClient httpClient) {
+	public void setHttpClient(CloseableHttpClient httpClient) {
 		this.httpClient = httpClient;
 	}
 
@@ -69,7 +69,7 @@ public class CieloEcommerce {
 
 	/**
 	 * Create a card token to be stored on store
-	 * 
+	 *
 	 * @param cardToken
 	 *            The credit card data
 	 * @return The card token
@@ -112,7 +112,7 @@ public class CieloEcommerce {
 
 		return sale;
 	}
-	
+
 	/**
 	 * Query a Sale on Cielo by paymentId
 	 *
@@ -136,7 +136,7 @@ public class CieloEcommerce {
 		return merchantOrder;
 	}
 
-	
+
 
 	/**
 	 * Query a RecurrentSale on Cielo by recurrentPaymentId

--- a/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/CreateCartTokenRequest.java
+++ b/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/CreateCartTokenRequest.java
@@ -2,7 +2,7 @@ package cieloecommerce.sdk.ecommerce.request;
 
 import java.io.IOException;
 
-import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 
@@ -24,7 +24,7 @@ public class CreateCartTokenRequest extends AbstractSaleRequest<CardToken, CardT
 
 		request.setEntity(new StringEntity(new GsonBuilder().create().toJson(param)));
 
-		HttpResponse response = sendRequest(request);
+		CloseableHttpResponse response = sendRequest(request);
 
 		return readResponse(response, CardToken.class);
 	}

--- a/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/CreateSaleRequest.java
+++ b/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/CreateSaleRequest.java
@@ -3,7 +3,7 @@ package cieloecommerce.sdk.ecommerce.request;
 import java.io.IOException;
 
 import org.apache.commons.codec.Charsets;
-import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
@@ -29,7 +29,7 @@ public class CreateSaleRequest extends AbstractSaleRequest<Sale, Sale> {
 
 		request.setEntity(new StringEntity(new GsonBuilder().create().toJson(param),
 				ContentType.create(ContentType.APPLICATION_JSON.getMimeType(), Charsets.UTF_8.name())));
-		HttpResponse response = sendRequest(request);
+		CloseableHttpResponse response = sendRequest(request);
 
 		return readResponse(response, Sale.class);
 	}

--- a/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/DeactivateRecurrentSaleRequest.java
+++ b/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/DeactivateRecurrentSaleRequest.java
@@ -3,7 +3,7 @@ package cieloecommerce.sdk.ecommerce.request;
 import cieloecommerce.sdk.Environment;
 import cieloecommerce.sdk.Merchant;
 import cieloecommerce.sdk.ecommerce.RecurrentSale;
-import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPut;
 
 import java.io.IOException;
@@ -18,7 +18,7 @@ public class DeactivateRecurrentSaleRequest extends AbstractSaleRequest<String, 
         String url = environment.getApiUrl() + "1/RecurrentPayment/" + recurrentPaymentId + "/Deactivate";
 
         HttpPut request = new HttpPut(url);
-        HttpResponse response = sendRequest(request);
+        CloseableHttpResponse response = sendRequest(request);
 
         return readResponse(response, RecurrentSale.class);
     }

--- a/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/QueryMerchantOrderRequest.java
+++ b/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/QueryMerchantOrderRequest.java
@@ -2,7 +2,7 @@ package cieloecommerce.sdk.ecommerce.request;
 
 import java.io.IOException;
 
-import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 
 import cieloecommerce.sdk.Environment;
@@ -22,9 +22,9 @@ public class QueryMerchantOrderRequest extends AbstractSaleRequest<String, Query
 		String url = environment.getApiQueryURL() + "1/sales?merchantOrderId=" + merchnatOrderId;
 
 		HttpGet request = new HttpGet(url);
-		HttpResponse response = sendRequest(request);
+		CloseableHttpResponse response = sendRequest(request);
 
 		return readResponse(response, QueryMerchantOrderResponse.class);
 	}
-	
+
 }

--- a/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/QueryRecurrentSaleRequest.java
+++ b/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/QueryRecurrentSaleRequest.java
@@ -2,7 +2,7 @@ package cieloecommerce.sdk.ecommerce.request;
 
 import java.io.IOException;
 
-import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 
 import cieloecommerce.sdk.Environment;
@@ -19,7 +19,7 @@ public class QueryRecurrentSaleRequest extends AbstractSaleRequest<String, Recur
         String url = environment.getApiQueryURL() + "1/RecurrentPayment/" + recurrentPaymentId;
 
         HttpGet request = new HttpGet(url);
-        HttpResponse response = sendRequest(request);
+        CloseableHttpResponse response = sendRequest(request);
 
         return readResponse(response, RecurrentSale.class);
     }

--- a/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/QuerySaleRequest.java
+++ b/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/QuerySaleRequest.java
@@ -2,7 +2,7 @@ package cieloecommerce.sdk.ecommerce.request;
 
 import java.io.IOException;
 
-import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 
 import cieloecommerce.sdk.Environment;
@@ -22,7 +22,7 @@ public class QuerySaleRequest extends AbstractSaleRequest<String, Sale> {
 		String url = environment.getApiQueryURL() + "1/sales/" + paymentId;
 
 		HttpGet request = new HttpGet(url);
-		HttpResponse response = sendRequest(request);
+		CloseableHttpResponse response = sendRequest(request);
 
 		return readResponse(response, Sale.class);
 	}

--- a/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/UpdateSaleRequest.java
+++ b/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/UpdateSaleRequest.java
@@ -3,7 +3,7 @@ package cieloecommerce.sdk.ecommerce.request;
 import cieloecommerce.sdk.Environment;
 import cieloecommerce.sdk.Merchant;
 import cieloecommerce.sdk.ecommerce.SaleResponse;
-import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.utils.URIBuilder;
 
@@ -43,7 +43,7 @@ public class UpdateSaleRequest extends AbstractSaleRequest<String, SaleResponse>
 
 			request = new HttpPut(builder.build().toString());
 
-			HttpResponse response = sendRequest(request);
+			CloseableHttpResponse response = sendRequest(request);
 
 			sale = readResponse(response, SaleResponse.class);
 		} catch (URISyntaxException e) {


### PR DESCRIPTION
Consome a entidade e invoca o metodo close do CloseableHttpResponse para
evitar vazamento de conexoes.
Esta mudanca e particularmente importante quando a instancia do HttpClient
for definida pelo cliente, pois permite a utilizacao de um HttpClient
configurado com um gerenciador de conexoes do tipo
PoolingHttpClientConnectionManager

Signed-off-by: Gabriel Oliveira <gabriel.oliveira@evoluservices.com>